### PR TITLE
add a checkbox to enable/disable filters on the fly

### DIFF
--- a/public/examples/crop_trim.json
+++ b/public/examples/crop_trim.json
@@ -12,7 +12,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -36,7 +37,8 @@
           "v"
         ],
         "outputs": [],
-        "nodeType": "output"
+        "nodeType": "output",
+        "enabled": true
       },
       "nodeType": "output",
       "position": {
@@ -140,7 +142,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -261,7 +264,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {

--- a/public/examples/grid.json
+++ b/public/examples/grid.json
@@ -12,7 +12,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -38,7 +39,8 @@
           "a"
         ],
         "outputs": [],
-        "nodeType": "output"
+        "nodeType": "output",
+        "enabled": true
       },
       "nodeType": "output",
       "position": {
@@ -116,7 +118,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -170,7 +173,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -197,7 +201,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {

--- a/public/examples/mirror.json
+++ b/public/examples/mirror.json
@@ -12,7 +12,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -38,7 +39,8 @@
           "a"
         ],
         "outputs": [],
-        "nodeType": "output"
+        "nodeType": "output",
+        "enabled": true
       },
       "nodeType": "output",
       "position": {
@@ -80,7 +82,8 @@
             "value": 2
           }
         ],
-        "nodeType": "filter"
+        "nodeType": "filter",
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -162,7 +165,8 @@
             "value": "false"
           }
         ],
-        "nodeType": "filter"
+        "nodeType": "filter",
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -204,7 +208,8 @@
             "value": 2
           }
         ],
-        "nodeType": "filter"
+        "nodeType": "filter",
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -235,7 +240,8 @@
           "v"
         ],
         "params": [],
-        "nodeType": "filter"
+        "nodeType": "filter",
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -286,7 +292,8 @@
             "value": "false"
           }
         ],
-        "nodeType": "filter"
+        "nodeType": "filter",
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {

--- a/public/examples/scale_overlay.json
+++ b/public/examples/scale_overlay.json
@@ -12,7 +12,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -211,7 +212,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -238,7 +240,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -600,7 +603,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {

--- a/public/examples/smooth_slow.json
+++ b/public/examples/smooth_slow.json
@@ -12,7 +12,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -37,7 +38,8 @@
           "a"
         ],
         "outputs": [],
-        "nodeType": "output"
+        "nodeType": "output",
+        "enabled": true
       },
       "nodeType": "output",
       "position": {
@@ -79,7 +81,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -283,7 +286,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -324,7 +328,8 @@
         ],
         "outputs": [
           "a"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {

--- a/public/examples/speedup.json
+++ b/public/examples/speedup.json
@@ -12,7 +12,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -37,7 +38,8 @@
           "a"
         ],
         "outputs": [],
-        "nodeType": "output"
+        "nodeType": "output",
+        "enabled": true
       },
       "nodeType": "output",
       "position": {
@@ -79,7 +81,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {

--- a/public/examples/text.json
+++ b/public/examples/text.json
@@ -12,7 +12,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -37,7 +38,8 @@
           "a"
         ],
         "outputs": [],
-        "nodeType": "output"
+        "nodeType": "output",
+        "enabled": true
       },
       "nodeType": "output",
       "position": {
@@ -456,7 +458,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {

--- a/public/examples/xfade.json
+++ b/public/examples/xfade.json
@@ -12,7 +12,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {
@@ -37,7 +38,8 @@
           "a"
         ],
         "outputs": [],
-        "nodeType": "output"
+        "nodeType": "output",
+        "enabled": true
       },
       "nodeType": "output",
       "position": {
@@ -295,7 +297,8 @@
         ],
         "outputs": [
           "v"
-        ]
+        ],
+        "enabled": true
       },
       "nodeType": "filter",
       "position": {
@@ -321,7 +324,8 @@
           "a"
         ],
         "inputs": [],
-        "nodeType": "input"
+        "nodeType": "input",
+        "enabled": true
       },
       "nodeType": "input",
       "position": {

--- a/src/Node.svelte
+++ b/src/Node.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
   import { Handle, Position } from "@xyflow/svelte";
-  import { removeNode, nodes, INPUTNAMES, OUTPUTNAMES, selectedFilter } from "./stores.js";
+  import { removeNode, nodes, updateNode, INPUTNAMES, OUTPUTNAMES, selectedFilter } from "./stores.js";
 
-  export let data = { ext: "", nodeType: "", name: "", inputs: [], outputs: [] };
+  export let data = { ext: "", nodeType: "", name: "", inputs: [], outputs: [], enabled: true };
   export let id;
 
   $: isSelected = $selectedFilter && $nodes[$selectedFilter] && $nodes[$selectedFilter].id === id;
 
   function remove() {
     removeNode(id);
+  }
+
+  function updateEnabled(e){
+    data.enabled = e.target.checked;
+    updateNode(id, data);
   }
 
   function resetNode() {
@@ -28,8 +33,12 @@
   }
 </script>
 
-<div class="node {data.nodeType} {isSelected ? 'selected' : ''}">
+<div class="node {data.nodeType} {isSelected ? 'selected' : ''} {data.enabled || data.enabled === undefined ? '' : 'disabled'}">
   <div class="head">
+    {#if data.nodeType === "filter"}
+      <input type="checkbox" on:change={updateEnabled} checked={data.enabled}/>
+    {/if}
+
     <div class="node-type">{data.nodeType}</div>
     {#if data.nodeType != "output"}
       <button on:click={remove}>X</button>
@@ -106,6 +115,11 @@
     outline: 2px solid var(--b1);
     background-color: var(--b2);
   }
+
+  .disabled {
+    outline: 2px solid red !important;
+  }
+
   .head {
     display: flex;
     justify-content: space-between;

--- a/src/stores.js
+++ b/src/stores.js
@@ -93,7 +93,7 @@ export const previewCommand = derived([edges, nodes], ([$edges, $nodes]) => {
     }
   }
 
-  for (let n of $nodes.filter((n) => n.nodeType == "filter")) {
+  for (let n of $nodes.filter((n) => n.nodeType == "filter" && n.data.enabled)) {
     let cmd = { weight: 0, in: [], out: [], cmd: "" };
 
     const outs = $edges.filter((e) => e.source == n.id);
@@ -258,6 +258,7 @@ export function addNode(_data, type) {
   data.nodeType = type;
   data.inputs = ins;
   data.outputs = outs;
+  data.enabled = true;
 
   let node = {
     id: uuidv4(),
@@ -350,6 +351,16 @@ export function removeNode(id) {
     _nodes.splice(index, 1);
     return _nodes;
   });
+}
+
+export function updateNode(id, data){
+  nodes.update((_nodes)=>{
+    const node = _nodes.find((n)=>n.id === id);
+    if(node){
+      node.data = data;
+    }
+    return _nodes;
+  })
 }
 
 export function removeEdge(id) {


### PR DESCRIPTION
Saw this on the TODO list!

- filter have a checkbox to enabled/disable (I am terrible at UI so I just put it there and am open to any feedback as to look/location/etc.)
- disabled filters are skipped in processing for the command
- inputs/outputs technically have the disabled property too but I'm not sure what that should mean so it is suppressed